### PR TITLE
chore: add pyproject.toml to avoid easy_install usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.


### PR DESCRIPTION
In speaking about other changes, it came up that if you don't use a PEP 517 build for this, setup_requires goes through the deprecated easy_install mechanism, which is dangerous and buggy.

Adding this pyproject.toml will ensure that doesn't happen.
