### PR TITLE
fix: retrieve package version at runtime

### DIFF
--- a/scripts/manylinux/check.sh
+++ b/scripts/manylinux/check.sh
@@ -18,7 +18,8 @@
 set -e -x
 echo "CHECKING ON LINUX"
 
-PACKAGE_VERSION=0.0.2
+VERSION=$(awk "/version \= ([0-9.]+)/" setup.cfg)
+PACKAGE_VERSION=${VERSION:10}
 WHEEL_FILE="wheels/google_crc32c-${PACKAGE_VERSION}-cp36-cp36m-manylinux1_x86_64.whl"
 PYTHON=python3.6
 

--- a/scripts/osx/check.sh
+++ b/scripts/osx/check.sh
@@ -15,7 +15,8 @@
 
 set -e -x
 echo "CHECKING OSX WHEELS"
-PACKAGE_VERSION=0.0.2
+VERSION=$(awk "/version \= ([0-9.]+)/" setup.cfg)
+PACKAGE_VERSION=${VERSION:10}
 
 # ``readlink -f`` is not our friend on OS X. This relies on **some**
 # ``python`` being installed.


### PR DESCRIPTION
Instead of hardcoding the version assume we can find it in setup.cfg.