### PR TITLE
Use the correct order of arguments for `warnings.warn` function

### DIFF
--- a/src/crc32c/__init__.py
+++ b/src/crc32c/__init__.py
@@ -26,7 +26,7 @@ try:
     implementation = "cffi"
 except ImportError:
     from crc32c import python as _crc32c
-    warnings.warn(RuntimeWarning, "_SLOW_CRC32C_WARNING",)
+    warnings.warn("_SLOW_CRC32C_WARNING", RuntimeWarning)
     implementation = "python"
 
 extend = _crc32c.extend


### PR DESCRIPTION
There is a mistake with the order of arguments in `warnings.warn` function call, and because of this mistake the library errors when CFFI C extension is not available. It basically means the pure Python implementation of CFFI cannot be used.

Here is the error:
```
c:\users\runneradmin\appdata\local\pypoetry\cache\virtualenvs\rasa-8anjnmh4-py3.8\lib\site-packages\crc32c\__init__.py:29: in <module>
51
    warnings.warn(RuntimeWarning, "_SLOW_CRC32C_WARNING",)
52
E   TypeError: category must be a Warning subclass, not 'str'
```
