### PR TITLE
fix: add LICENSE to package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include src/google_crc32c_build.py
+include LICENSE


### PR DESCRIPTION
Add LICENSE file to ensure that it's part of the source tarball released on PyPI.

The LICENSE must be shipped by the package provided by most distributions.