### PR TITLE
feat: add Python 3.9 support, drop Python 3.5 support

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,7 @@ import nox
 from sys import platform
 
 
-@nox.session(python=["3.5", "3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
 def build_libcrc32c(session):
     if platform.startswith("win"):
         session.run("cmd", "-c", "scripts\\windows\\build.bat")
@@ -33,7 +33,7 @@ def build_libcrc32c(session):
         raise Exception("Unsupported")
 
 
-@nox.session(python=["3.5", "3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
 def check(session):
     session.install("cffi>=1.0.0")
     session.install("--no-index", "--find-links=wheels", "google-crc32c")

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,7 @@ import nox
 from sys import platform
 
 
-@nox.session(python=["3.5", "3.6", "3.7", "3.8"])
+@nox.session(python=["3.5", "3.6", "3.7", "3.8", "3.9"])
 def build_libcrc32c(session):
     if platform.startswith("win"):
         session.run("cmd", "-c", "scripts\\windows\\build.bat")
@@ -33,8 +33,9 @@ def build_libcrc32c(session):
         raise Exception("Unsupported")
 
 
-@nox.session(python=["3.5", "3.6", "3.7", "3.8"])
+@nox.session(python=["3.5", "3.6", "3.7", "3.8", "3.9"])
 def check(session):
+    session.install("cffi>=1.0.0")
     session.install("--no-index", "--find-links=wheels", "google-crc32c")
 
     # Run py.test against the unit tests.

--- a/scripts/manylinux/build_on_centos.sh
+++ b/scripts/manylinux/build_on_centos.sh
@@ -40,10 +40,7 @@ make all install
 VERSION_WHITELIST=""
 for PYTHON_BIN in /opt/python/*/bin; do
     # H/T: https://stackoverflow.com/a/229606/1068170
-    if [[ "${PYTHON_BIN}" == *"35"* ]]; then
-        VERSION_WHITELIST="${VERSION_WHITELIST} ${PYTHON_BIN}"
-        continue
-    elif [[ "${PYTHON_BIN}" == *"36"* ]]; then
+    if [[ "${PYTHON_BIN}" == *"36"* ]]; then
         VERSION_WHITELIST="${VERSION_WHITELIST} ${PYTHON_BIN}"
         continue
     elif [[ "${PYTHON_BIN}" == *"37"* ]]; then

--- a/scripts/manylinux/build_on_centos.sh
+++ b/scripts/manylinux/build_on_centos.sh
@@ -52,6 +52,9 @@ for PYTHON_BIN in /opt/python/*/bin; do
     elif [[ "${PYTHON_BIN}" == *"38"* ]]; then
         VERSION_WHITELIST="${VERSION_WHITELIST} ${PYTHON_BIN}"
         continue
+    elif [[ "${PYTHON_BIN}" == *"39"* ]]; then
+        VERSION_WHITELIST="${VERSION_WHITELIST} ${PYTHON_BIN}"
+        continue
     else
         echo "Ignoring unsupported version: ${PYTHON_BIN}"
         echo "====================================="

--- a/scripts/osx/build.sh
+++ b/scripts/osx/build.sh
@@ -54,10 +54,11 @@ export PY_BIN="python3.8"
 export PY_TAG="cp38-cp38"
 ${OSX_DIR}/build_python_wheel.sh
 
+# TODO: As of 2020-12-11, 3.9 is not available on our CI
 # Build wheel for Python 3.9.
-export PY_BIN="python3.9"
-export PY_TAG="cp39-cp39"
-${OSX_DIR}/build_python_wheel.sh
+#export PY_BIN="python3.9"
+#export PY_TAG="cp39-cp39"
+#${OSX_DIR}/build_python_wheel.sh
 
 
 # Clean up.

--- a/scripts/osx/build.sh
+++ b/scripts/osx/build.sh
@@ -49,13 +49,14 @@ export PY_TAG="cp37-cp37m"
 ${OSX_DIR}/build_python_wheel.sh
 
 # Build wheel for Python 3.8.
+# Note that the 'm' SOABI flag is no longer supported for Python >= 3.8
 export PY_BIN="python3.8"
-export PY_TAG="cp38-cp38m"
+export PY_TAG="cp38-cp38"
 ${OSX_DIR}/build_python_wheel.sh
 
 # Build wheel for Python 3.9.
 export PY_BIN="python3.9"
-export PY_TAG="cp39-cp39m"
+export PY_TAG="cp39-cp39"
 ${OSX_DIR}/build_python_wheel.sh
 
 

--- a/scripts/osx/build.sh
+++ b/scripts/osx/build.sh
@@ -28,6 +28,7 @@ PYTHON35="/Library/Frameworks/Python.framework/Versions/3.5/bin"
 PYTHON36="/Library/Frameworks/Python.framework/Versions/3.6/bin"
 PYTHON37="/Library/Frameworks/Python.framework/Versions/3.7/bin"
 PYTHON38="/Library/Frameworks/Python.framework/Versions/3.8/bin"
+PYTHON39="/Library/Frameworks/Python.framework/Versions/3.9/bin"
 
 # Build and install `libcrc32c`
 export PY_BIN="python3"
@@ -53,11 +54,15 @@ export PY_BIN="python3.7"
 export PY_TAG="cp37-cp37m"
 ${OSX_DIR}/build_python_wheel.sh
 
-# TODO: As of 2019-Dec-30, 3.8 is not available on our CI
-# Build wheel for Python 3.7.
-# export PY_BIN="python3.8"
-# export PY_TAG="cp38-cp38m"
-# ${OSX_DIR}/build_python_wheel.sh
+# Build wheel for Python 3.8.
+export PY_BIN="python3.8"
+export PY_TAG="cp38-cp38m"
+${OSX_DIR}/build_python_wheel.sh
+
+# Build wheel for Python 3.9.
+export PY_BIN="python3.9"
+export PY_TAG="cp39-cp39m"
+${OSX_DIR}/build_python_wheel.sh
 
 
 # Clean up.

--- a/scripts/osx/build.sh
+++ b/scripts/osx/build.sh
@@ -24,7 +24,6 @@ SCRIPTS_DIR=$(dirname ${OSX_DIR})
 export REPO_ROOT=$(dirname ${SCRIPTS_DIR})
 
 # NOTE: These are the Python.org versions of Python.
-PYTHON35="/Library/Frameworks/Python.framework/Versions/3.5/bin"
 PYTHON36="/Library/Frameworks/Python.framework/Versions/3.6/bin"
 PYTHON37="/Library/Frameworks/Python.framework/Versions/3.7/bin"
 PYTHON38="/Library/Frameworks/Python.framework/Versions/3.8/bin"
@@ -38,11 +37,6 @@ cd ${REPO_ROOT}
 git submodule update --init --recursive
 
 ${OSX_DIR}/build_c_lib.sh
-
-# Build wheel for Python 3.5.
-export PY_BIN="python3.5"
-export PY_TAG="cp35-cp35m"
-${OSX_DIR}/build_python_wheel.sh
 
 # Build wheel for Python 3.6.
 export PY_BIN="python3.6"

--- a/scripts/osx/check.sh
+++ b/scripts/osx/check.sh
@@ -63,7 +63,7 @@ rm -fr venv37
 
 ${PYTHON38}/python3 -m venv venv38
 curl https://bootstrap.pypa.io/get-pip.py | venv38/bin/python3
-WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp38-cp38-macosx_10_9_intel.whl
+WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp38-cp38-macosx_10_9_x86_64.whl
 venv38/bin/pip install ${WHL}
 venv38/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 ${LISTDEPS_CMD} ${WHL}

--- a/scripts/osx/check.sh
+++ b/scripts/osx/check.sh
@@ -28,7 +28,6 @@ export REPO_ROOT=$(dirname ${SCRIPTS_DIR})
 ls ${REPO_ROOT}/wheels
 
 # NOTE: These are the Python.org versions of Python.
-PYTHON35="/Library/Frameworks/Python.framework/Versions/3.5/bin"
 PYTHON36="/Library/Frameworks/Python.framework/Versions/3.6/bin"
 PYTHON37="/Library/Frameworks/Python.framework/Versions/3.7/bin"
 PYTHON38="/Library/Frameworks/Python.framework/Versions/3.8/bin"
@@ -45,13 +44,6 @@ ${PYTHON37}/python3 -m pip install --upgrade delocate
 LISTDEPS_CMD="${PYTHON37}/delocate-listdeps --all --depending"
 VIRTUALENV_CMD="${PYTHON37}/python3 -m venv"
 
-${PYTHON35}/python3 -m venv venv35
-curl https://bootstrap.pypa.io/get-pip.py | venv35/bin/python3
-WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp35-cp35m-macosx_10_6_intel.whl
-venv35/bin/pip install ${WHL}
-venv35/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
-${LISTDEPS_CMD} ${WHL}
-rm -fr venv35
 
 ${PYTHON36}/python3 -m venv venv36
 curl https://bootstrap.pypa.io/get-pip.py | venv36/bin/python3
@@ -69,11 +61,19 @@ venv37/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 ${LISTDEPS_CMD} ${WHL}
 rm -fr venv37
 
-# TODO: As of 2019-Dec-30, 3.8 is not available on our CI
-# ${PYTHON38}/python3 -m venv venv38
-# curl https://bootstrap.pypa.io/get-pip.py | venv38/bin/python3
-# WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp38-cp38m-macosx_10_9_x86_64.whl
+${PYTHON38}/python3 -m venv venv38
+curl https://bootstrap.pypa.io/get-pip.py | venv38/bin/python3
+WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp38-cp38-macosx_10_6_intel.whl
+venv38/bin/pip install ${WHL}
+venv38/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
+${LISTDEPS_CMD} ${WHL}
+rm -fr venv38
+
+# TODO: As of 2020-12-11, 3.9 is not available on our CI
+# ${PYTHON39}/python3 -m venv venv39
+# curl https://bootstrap.pypa.io/get-pip.py | venv39/bin/python3
+# WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp39-cp39-macosx_10_9_x86_64.whl
 # venv37/bin/pip install ${WHL}
 # venv37/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 # ${LISTDEPS_CMD} ${WHL}
-# rm -fr venv38
+# rm -fr venv39

--- a/scripts/osx/check.sh
+++ b/scripts/osx/check.sh
@@ -63,7 +63,7 @@ rm -fr venv37
 
 ${PYTHON38}/python3 -m venv venv38
 curl https://bootstrap.pypa.io/get-pip.py | venv38/bin/python3
-WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp38-cp38-macosx_10_6_intel.whl
+WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp38-cp38-macosx_10_9_intel.whl
 venv38/bin/pip install ${WHL}
 venv38/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 ${LISTDEPS_CMD} ${WHL}

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -49,7 +49,7 @@ popd
 copy %CRC32C_INSTALL_PREFIX%bin\google_crc32c.dll .
 
 @rem update python deps and build wheels (requires CRC32C_INSTALL_PREFIX is set)
-FOR %%V IN (3.5-64,3.6-64,3.7-64) DO (
+FOR %%V IN (3.6-64,3.7-64) DO (
     py -%%V -m pip install --upgrade pip setuptools wheel
     py -%%V -m pip wheel . --wheel-dir wheels/
 )
@@ -77,7 +77,7 @@ popd
 copy %CRC32C_INSTALL_PREFIX%bin\google_crc32c.dll .
 
 @rem update python deps and build wheels (requires CRC32C_INSTALL_PREFIX is set)
-FOR %%V IN (3.5-32,3.6-32,3.7-32) DO (
+FOR %%V IN (3.6-32,3.7-32) DO (
     py -%%V -m pip install --upgrade pip setuptools wheel
     py -%%V -m pip wheel . --wheel-dir wheels/
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -38,7 +37,7 @@ classifiers =
     
 [options]
 zip_safe = True
-python_requires = >=3.5
+python_requires = >=3.6
 
 [options.extras_require]
 testing = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     
 [options]
 zip_safe = True


### PR DESCRIPTION
See #38.
See #40.

~~Both~~ The `scripts/osx/` ~~and `scripts/windows/`~~ change is a wild stabs:  I have no idea whether ~~they~~ it actually works.