### PR TITLE
chore: renovate ignore 'scripts/dev-requirements.txt'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "ignorePaths": [".pre-commit-config.yaml"],
+  "ignorePaths": [".pre-commit-config.yaml", "scripts/dev-requirements.txt"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
In spite of its name, the file is actually for documentation purposes:
the minimum values it documents are important.

Closes #74.