### PR TITLE
fix: advise setting 'CRC32C_PURE_PYTHON' after build failure

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Build
       env:
         BUILD_PYTHON: ${{ matrix.python }}
+        CRC32C_PURE_PYTHON: "0"
       run: |
         ./scripts/manylinux/build.sh
     - name: Test Import
@@ -76,6 +77,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel
     - name: Build
+      env:
+        CRC32C_PURE_PYTHON: "0"
       run: |
         ./scripts/osx/build_gh_action.sh
     - name: Test Import
@@ -116,6 +119,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel
     - name: Build
+      env:
+        CRC32C_PURE_PYTHON: "0"
       run: |
         where python
         ./scripts/windows/build.bat ${{ matrix.python }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Build
       env:
         BUILD_PYTHON: ${{ matrix.python }}
+        CRC32C_PURE_PYTHON: "0"
       run: |
         ./scripts/manylinux/build.sh
     - name: Test Import
@@ -68,6 +69,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel
     - name: Build
+      env:
+        CRC32C_PURE_PYTHON: "0"
       run: |
         ./scripts/osx/build_gh_action.sh
     - name: Test Import
@@ -104,6 +107,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel
     - name: Build
+      env:
+        CRC32C_PURE_PYTHON: "0"
       run: |
         where python
         ./scripts/windows/build.bat ${{ matrix.python }}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ _DLL_FILENAME = "crc32c.dll"
 
 # Explicit environment variable disables pure-Python fallback
 CRC32C_PURE_PYTHON_EXPLICIT = "CRC32C_PURE_PYTHON" in os.environ
-_FALSE_OPTIONS = ("0", "false", "no", None)
+_FALSE_OPTIONS = ("0", "false", "no", "False", "No", None)
 CRC32C_PURE_PYTHON = os.getenv("CRC32C_PURE_PYTHON") not in _FALSE_OPTIONS
 
 
@@ -73,8 +73,8 @@ else:
         )
     except SystemExit:
         if "CRC32C_PURE_PYTHON" not in os.environ:
-            # If build / insall fails, it is likely a compilation error with
-            # the C extension:  adviser user how to enable th pure-Python
+            # If build / install fails, it is likely a compilation error with
+            # the C extension:  advise user how to enable the pure-Python
             # build.
             logging.error(
                 "Compiling the C Extension for the crc32c library failed. "

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import shutil
 import setuptools
 import setuptools.command.build_ext
-import warnings
 
 _EXTRA_DLL = "extra-dll"
 _DLL_FILENAME = "crc32c.dll"
-CRC32C_PURE_PYTHON = os.getenv("CRC32C_PURE_PYTHON") is not None
+
+# Explicit environment variable disables pure-Python fallback
+CRC32C_PURE_PYTHON_EXPLICIT = "CRC32C_PURE_PYTHON" in os.environ
+_FALSE_OPTIONS = ("0", "false", "no", None)
+CRC32C_PURE_PYTHON = os.getenv("CRC32C_PURE_PYTHON") not in _FALSE_OPTIONS
 
 
 def copy_dll(build_lib):
@@ -54,14 +58,27 @@ module = setuptools.Extension(
 
 
 if CRC32C_PURE_PYTHON:
-    ext_modules = []
+    setuptools.setup(
+        packages=["google_crc32c"],
+        package_dir={"": "src"},
+        ext_modules=[],
+    )
 else:
-    ext_modules = [module]
-
-
-setuptools.setup(
-    packages=["google_crc32c"],
-    package_dir={"": "src"},
-    ext_modules=ext_modules,
-    cmdclass={"build_ext": BuildExtWithDLL},
-)
+    try:
+        setuptools.setup(
+            packages=["google_crc32c"],
+            package_dir={"": "src"},
+            ext_modules=[module],
+            cmdclass={"build_ext": BuildExtWithDLL},
+        )
+    except SystemExit:
+        if "CRC32C_PURE_PYTHON" not in os.environ:
+            # If build / insall fails, it is likely a compilation error with
+            # the C extension:  adviser user how to enable th pure-Python
+            # build.
+            logging.error(
+                "Compiling the C Extension for the crc32c library failed. "
+                "To enable building / installing a pure-Python-only version, "
+                "set 'CRC32C_PURE_PYTHON=1' in the environment."
+            )
+        raise


### PR DESCRIPTION
Toward #83.