### PR TITLE
tests: make check run tests w/ verbose

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Run tests
       run: |
         pip install pytest
-        python -m pytest tests
+        python -m pytest --verbose tests
     - uses: actions/upload-artifact@v2
       with:
         name: python-package-distributions
@@ -90,7 +90,7 @@ jobs:
     - name: Run tests
       run: |
         pip install pytest
-        python -m pytest tests
+        python -m pytest --verbose tests
     - uses: actions/upload-artifact@v2
       with:
         name: python-package-distributions

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run tests
       run: |
         pip install pytest
-        python -m pytest tests
+        python -m pytest --verbose tests
     - uses: actions/upload-artifact@v2
       with:
         name: python-package-distributions
@@ -80,7 +80,7 @@ jobs:
     - name: Run tests
       run: |
         pip install pytest
-        python -m pytest tests
+        python -m pytest --verbose tests
     - uses: actions/upload-artifact@v2
       with:
         name: python-package-distributions

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,5 +45,5 @@ def check(session):
     session.install("--no-index", f"--find-links={HERE}/wheels", "google-crc32c")
 
     # Run py.test against the unit tests.
-    session.run("py.test", "tests")
+    session.run("py.test", "-v", "tests")
     session.run("python", f"{HERE}/scripts/check_crc32c_extension.py", *session.posargs)


### PR DESCRIPTION
So eyeballs can verify that the 'cext' tests get run.