### PR TITLE
feat: restore CFFI build as an alternative to the C extension

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -49,9 +49,42 @@ jobs:
         ./scripts/manylinux/build.sh
     - name: Test Import
       run: |
-        pip install "cffi>=1.0.0"
         pip install --no-index --find-links=wheels google-crc32c
         python ./scripts/check_crc32c_extension.py
+    - name: Run tests
+      run: |
+        pip install pytest
+        python -m pytest tests
+    - uses: actions/upload-artifact@v2
+      with:
+        name: linux-wheels
+        path: ./wheels/google_crc32c*.whl
+
+  build-linux-cffi:
+    # Test w/ the CFFI build, but only on Python 3.9, and without
+    # uploading the wheel.
+    runs-on: ubuntu-latest
+    strategy:
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+    - name: Build
+      env:
+        BUILD_PYTHON: 3.9
+        CRC32C_PURE_PYTHON: "0"
+        CRC32C_CFFI: "1"
+      run: |
+        ./scripts/manylinux/build.sh
+    - name: Test Import
+      run: |
+        pip install "cffi>=1.0.0"
+        pip install --no-index --find-links=wheels google-crc32c
         python ./scripts/check_cffi_crc32c.py
     - name: Run tests
       run: |
@@ -59,7 +92,7 @@ jobs:
         python -m pytest tests
     - uses: actions/upload-artifact@v2
       with:
-        name: python-package-distributions
+        name: linux-cffi-wheel
         path: ./wheels/google_crc32c*.whl
 
   build-macos:
@@ -90,14 +123,13 @@ jobs:
         pip install "cffi>=1.0.0"
         pip install --no-index --find-links=wheels google-crc32c
         python ./scripts/check_crc32c_extension.py
-        python ./scripts/check_cffi_crc32c.py
     - name: Run tests
       run: |
         pip install pytest
         python -m pytest tests
     - uses: actions/upload-artifact@v2
       with:
-        name: python-package-distributions
+        name: macos-wheele
         path: ./wheels/google_crc32c*.whl
 
   build-windows:
@@ -134,5 +166,5 @@ jobs:
         ./scripts/windows/test.bat ${{ matrix.python }}
     - uses: actions/upload-artifact@v2
       with:
-        name: python-package-distributions
+        name: windows-wheele
         path: ./wheels/google_crc32c*.whl

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -64,7 +64,6 @@ jobs:
     # Test w/ the CFFI build, but only on Python 3.9, and without
     # uploading the wheel.
     runs-on: ubuntu-latest
-    strategy:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -49,8 +49,10 @@ jobs:
         ./scripts/manylinux/build.sh
     - name: Test Import
       run: |
+        pip install "cffi>=1.0.0"
         pip install --no-index --find-links=wheels google-crc32c
         python ./scripts/check_crc32c_extension.py
+        python ./scripts/check_cffi_crc32c.py
     - name: Run tests
       run: |
         pip install pytest
@@ -85,8 +87,10 @@ jobs:
         ./scripts/osx/build_gh_action.sh
     - name: Test Import
       run: |
+        pip install "cffi>=1.0.0"
         pip install --no-index --find-links=wheels google-crc32c
         python ./scripts/check_crc32c_extension.py
+        python ./scripts/check_cffi_crc32c.py
     - name: Run tests
       run: |
         pip install pytest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,8 +42,10 @@ jobs:
         ./scripts/manylinux/build.sh
     - name: Test Import
       run: |
+        pip install "cffi>=1.0.0"
         pip install --no-index --find-links=wheels google-crc32c
         python ./scripts/check_crc32c_extension.py
+        python ./scripts/check_cffi_crc32c.py
     - name: Run tests
       run: |
         pip install pytest
@@ -75,8 +77,10 @@ jobs:
         ./scripts/osx/build_gh_action.sh
     - name: Test Import
       run: |
+        pip install "cffi>=1.0.0"
         pip install --no-index --find-links=wheels google-crc32c
         python ./scripts/check_crc32c_extension.py
+        python ./scripts/check_cffi_crc32c.py
     - name: Run tests
       run: |
         pip install pytest

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,10 +75,6 @@ $ cd ../..
 Now, run the tests:
 
 ```bash
-$ venv/bin/python setup.py build_ext \
-    --include-dirs=$(pwd)/usr/include \
-    --library-dirs=$(pwd)/usr/lib \
-    --rpath=$(pwd)/usr/lib
 $ venv/bin/pip install -e .[testing]
 $ venv/bin/py.test tests/
 ============================= test session starts ==============================

--- a/scripts/check_cffi_crc32c.py
+++ b/scripts/check_cffi_crc32c.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 try:
-    from google_crc32c import _crc32c
+    from google_crc32c import _crc32c_cffi
 except ImportError:
-    _crc32c = None
+    _crc32c_cffi = None
 
 
 def main():
-    print("_crc32c: {}".format(_crc32c))
-    if _crc32c is not None:
-        print("dir(_crc32c): {}".format(dir(_crc32c)))
+    print("_crc32c_cffi: {}".format(_crc32c_cffi))
+    if _crc32c_cffi is not None:
+        print("_crc32c_cffi.lib: {}".format(_crc32c_cffi.lib))
+        print("dir(_crc32c_cffi.lib): {}".format(dir(_crc32c_cffi.lib)))
 
 
 if __name__ == "__main__":

--- a/scripts/local-linux/build_libcrc32c.sh
+++ b/scripts/local-linux/build_libcrc32c.sh
@@ -17,7 +17,7 @@ set -e -x
 PY_BIN=${PY_BIN:-python3.7}
 REPO_ROOT=${REPO_ROOT:-$(pwd)}
 
-CRC32C_INSTALL_PREFIX=${REPO_ROOT}/usr
+export CRC32C_INSTALL_PREFIX=${REPO_ROOT}/usr
 
 # NOTE: This assumes the local install has an up-to-date `pip`.
 # Create a virtualenv where we can install `cmake`.
@@ -44,11 +44,7 @@ make all install
 
 cd ${REPO_ROOT}
 
-${VENV}/bin/python setup.py build_ext \
-    --include-dirs=${REPO_ROOT}/usr/include \
-    --library-dirs=${REPO_ROOT}/usr/lib \
-    --rpath=${REPO_ROOT}/usr/lib
-${VENV}/bin/python -m pip wheel . --wheel-dir=wheels
+${VENV}/bin/python -m pip -v wheel . --wheel-dir=wheels
 
 # Clean up.
 rm -fr ${REPO_ROOT}/google_crc32c/build

--- a/scripts/manylinux/build.sh
+++ b/scripts/manylinux/build.sh
@@ -23,7 +23,7 @@ REPO_ROOT=$(dirname ${SCRIPTS_DIR})
 
 
 cd $REPO_ROOT
-git submodule update --init --recursive 
+git submodule update --init --recursive
 
 # Note:  PyPA's support for the 'manylinux1' image ends on 2022-01-01.
 #        See: https://github.com/pypa/manylinux/issues/994
@@ -39,7 +39,7 @@ if [[ "${BUILD_PYTHON}" != "3.10"* ]]; then
         /var/code/python-crc32c/scripts/manylinux/build_on_centos.sh
 fi
 
-docker pull quay.io/pypa/manylinux2010_x86_64	
+docker pull quay.io/pypa/manylinux2010_x86_64
 docker run \
     --rm \
     --interactive \

--- a/scripts/manylinux/build_on_centos.sh
+++ b/scripts/manylinux/build_on_centos.sh
@@ -80,7 +80,7 @@ for PYTHON_BIN in ${PYTHON_VERSIONS}; do
     ${PYTHON_BIN}/python -m pip install --upgrade pip
     ${PYTHON_BIN}/python -m pip install \
         --requirement ${REPO_ROOT}/scripts/dev-requirements.txt
-    ${PYTHON_BIN}/python -m pip wheel . --wheel-dir dist_wheels/
+    ${PYTHON_BIN}/python -m pip -v wheel . --wheel-dir dist_wheels/
 done
 
 # Bundle external shared libraries into the wheels

--- a/scripts/manylinux/check.sh
+++ b/scripts/manylinux/check.sh
@@ -38,6 +38,7 @@ venv/bin/pip install ${WHEEL_FILE}
 
 # Verify that the module is installed and peek at contents.
 venv/bin/python scripts/check_crc32c_extension.py
+venv/bin/python scripts/check_cffi_crc32c.py
 unzip -l ${WHEEL_FILE}
 
 # Clean up.

--- a/scripts/osx/build_python_wheel.sh
+++ b/scripts/osx/build_python_wheel.sh
@@ -44,11 +44,7 @@ ${VENV}/bin/python -m pip install \
 DIST_WHEELS="${REPO_ROOT}/dist_wheels"
 mkdir -p ${DIST_WHEELS}
 cd ${REPO_ROOT}
-${VENV}/bin/python setup.py build_ext \
-    --include-dirs=${REPO_ROOT}/usr/include \
-    --library-dirs=${REPO_ROOT}/usr/lib \
-    --rpath=${REPO_ROOT}/usr/lib
-${VENV}/bin/python -m pip wheel ${REPO_ROOT} --wheel-dir ${DIST_WHEELS}
+${VENV}/bin/python -m pip -v wheel ${REPO_ROOT} --wheel-dir ${DIST_WHEELS}
 
 # Delocate the wheel. removed --check-archs. We don't build i386.
 FIXED_WHEELS="${REPO_ROOT}/wheels"

--- a/scripts/osx/check.sh
+++ b/scripts/osx/check.sh
@@ -50,6 +50,7 @@ curl https://bootstrap.pypa.io/get-pip.py | venv36/bin/python3
 WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp36-cp36m-macosx_10_9_x86_64.whl
 venv36/bin/pip install ${WHL}
 venv36/bin/python ${REPO_ROOT}/scripts/check_crc32c_extension.py
+venv36/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 venv36/bin/pip install pytest
 venv36/bin/py.test ${REPO_ROOT}/tests
 ${LISTDEPS_CMD} ${WHL}
@@ -62,6 +63,7 @@ venv37/bin/pip install ${WHL}
 venv37/bin/pip install pytest
 venv37/bin/py.test ${REPO_ROOT}/tests
 venv37/bin/python ${REPO_ROOT}/scripts/check_crc32c_extension.py
+venv37/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 ${LISTDEPS_CMD} ${WHL}
 rm -fr venv37
 
@@ -72,6 +74,7 @@ venv38/bin/pip install ${WHL}
 venv38/bin/pip install pytest
 venv38/bin/py.test ${REPO_ROOT}/tests
 venv38/bin/python ${REPO_ROOT}/scripts/check_crc32c_extension.py
+venv38/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 ${LISTDEPS_CMD} ${WHL}
 rm -fr venv38
 
@@ -81,5 +84,6 @@ rm -fr venv38
 # WHL=${REPO_ROOT}/wheels/google_crc32c-${PACKAGE_VERSION}-cp39-cp39-macosx_10_9_x86_64.whl
 # venv37/bin/pip install ${WHL}
 # venv37/bin/python ${REPO_ROOT}/scripts/check_crc32c_extension.py
+# venv37/bin/python ${REPO_ROOT}/scripts/check_cffi_crc32c.py
 # ${LISTDEPS_CMD} ${WHL}
 # rm -fr venv39

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -73,8 +73,6 @@ FOR %%V IN (32,64) DO (
     copy %CRC32C_INSTALL_PREFIX%\bin\crc32c.dll .
 
     py -%PYTHON_VERSION%-%%V -m pip install --upgrade pip setuptools wheel
-    echo "Building C extension"
-    py -%PYTHON_VERSION%-%%V setup.py build_ext --include-dirs=%CRC32C_INSTALL_PREFIX%\include --library-dirs=%CRC32C_INSTALL_PREFIX%\lib
     echo "Building Wheel"
-    py -%PYTHON_VERSION%-%%V -m pip wheel . --wheel-dir wheels/
+    py -%PYTHON_VERSION%-%%V -m pip -v wheel . --wheel-dir wheels/
 )

--- a/scripts/windows/test.bat
+++ b/scripts/windows/test.bat
@@ -30,6 +30,7 @@ FOR %%V IN (%PYTHON_VERSION%-32, %PYTHON_VERSION%-64) DO (
     py -%%V -m pip install --no-index --find-links=wheels google-crc32c --force-reinstall
 
     py -%%V ./scripts/check_crc32c_extension.py
+    py -%%V ./scripts/check_cffi_crc32c.py
 
     py -%%V -m pip install pytest
     py -%%V -m pytest tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    
+
 [options]
 zip_safe = True
 python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 import shutil
+import sys
+
 import setuptools
 import setuptools.command.build_ext
 
@@ -25,6 +26,7 @@ _DLL_FILENAME = "crc32c.dll"
 CRC32C_PURE_PYTHON_EXPLICIT = "CRC32C_PURE_PYTHON" in os.environ
 _FALSE_OPTIONS = ("0", "false", "no", "False", "No", None)
 CRC32C_PURE_PYTHON = os.getenv("CRC32C_PURE_PYTHON") not in _FALSE_OPTIONS
+CRC32C_CFFI = os.getenv("CRC32C_CFFI") not in _FALSE_OPTIONS
 
 
 def copy_dll(build_lib):
@@ -49,50 +51,89 @@ class BuildExtWithDLL(setuptools.command.build_ext.build_ext):
         return result
 
 
-module_path = os.path.join("src", "google_crc32c", "_crc32c.c")
-module = setuptools.Extension(
-    "google_crc32c._crc32c",
-    sources=[os.path.normcase(module_path)],
-    libraries=["crc32c"],
-)
-
-
-def build_pure_python():
+def do_setup(**kwargs):
     setuptools.setup(
         packages=["google_crc32c"],
         package_dir={"": "src"},
-        ext_modules=[],
+        **kwargs
     )
 
 
 def build_c_extension():
-    setuptools.setup(
-        packages=["google_crc32c"],
-        package_dir={"": "src"},
+    install_prefix = os.getenv("CRC32C_INSTALL_PREFIX")
+    if install_prefix is not None:
+        install_prefix = os.path.realpath(install_prefix)
+        print(f"#### using local install of 'crc32c': {install_prefix}")
+        library_dirs = [os.path.join(install_prefix, "lib")]
+        if os.name == "nt":
+            library_dirs.append(os.path.join(install_prefix, "bin"))
+        kwargs = {
+            "include_dirs": [os.path.join(install_prefix, "include")],
+            "library_dirs": library_dirs,
+            "rpath": os.pathsep.join(library_dirs),
+        }
+    else:
+        print("#### using global install of 'crc32c'")
+        kwargs = {}
+
+    module_path = os.path.join("src", "google_crc32c", "_crc32c.c")
+    module = setuptools.Extension(
+        "google_crc32c._crc32c",
+        sources=[os.path.normcase(module_path)],
+        libraries=["crc32c"],
+        **kwargs,
+    )
+
+    do_setup(
         ext_modules=[module],
+        cmdclass={"build_ext": BuildExtWithDLL},
+    )
+
+def build_cffi():
+    build_path = os.path.join("src", "google_crc32c_build.py")
+    builder = "{}:FFIBUILDER".format(build_path)
+    cffi_dep = "cffi >= 1.0.0"
+    do_setup(
+        package_data={"google_crc32c": [os.path.join(_EXTRA_DLL, _DLL_FILENAME)]},
+        setup_requires=[cffi_dep],
+        cffi_modules=[builder],
+        install_requires=[cffi_dep],
         cmdclass={"build_ext": BuildExtWithDLL},
     )
 
 
 if CRC32C_PURE_PYTHON:
-    build_pure_python()
-else:
-    try:
-        build_c_extension()
-    except SystemExit:
-        if CRC32C_PURE_PYTHON_EXPLICIT:
-            # If build / install fails, it is likely a compilation error with
-            # the C extension:  advise user how to enable the pure-Python
-            # build.
-            logging.error(
-                "Compiling the C Extension for the crc32c library failed. "
-                "To enable building / installing a pure-Python-only version, "
-                "set 'CRC32C_PURE_PYTHON=1' in the environment."
-            )
-            raise
+    print("### Building explicitly-requested pure-Python version")
+    do_setup()
+    sys.exit(0)
 
-        logging.info(
-            "Compiling the C Extension for the crc32c library failed. "
-            "Falling back to pure Python build."
+if CRC32C_CFFI:
+    print("### Building explicitly-requested CFFI version")
+    builder = build_cffi
+    builder_name = "CFFI shim"
+else:
+    print("### Building C extension")
+    builder = build_c_extension
+    builder_name = "C extension"
+
+try:
+    builder()
+except SystemExit:
+    if CRC32C_PURE_PYTHON_EXPLICIT:
+        # If build / install fails, it is likely a compilation error with
+        # the C extension:  advise user how to enable the pure-Python
+        # build.
+        print(
+            f"Compiling the {builder_name} for the crc32c library failed. "
+            "To enable building / installing a pure-Python-only version, "
+            "set 'CRC32C_PURE_PYTHON=1' in the environment."
         )
-        build_pure_python()
+        raise
+
+    # Unfortunately, this output will not be visible under pip unless
+    # pip's verboseity is greater than the default.  Run `pip -v` to see it.
+    print(
+        f"Compiling the {builder_name} for the crc32c library failed. "
+        "Falling back to pure Python build."
+    )
+    do_setup()

--- a/src/google_crc32c/__init__.py
+++ b/src/google_crc32c/__init__.py
@@ -15,7 +15,7 @@
 import warnings
 
 _SLOW_CRC32C_WARNING = (
-    "As the c extension couldn't be imported, `google-crc32c` is using a " 
+    "As the c extension couldn't be imported, `google-crc32c` is using a "
     "pure python implementation that is significantly slower. If possible, "
     "please configure a c build environment and compile the extension"
 )

--- a/src/google_crc32c/__init__.py
+++ b/src/google_crc32c/__init__.py
@@ -25,9 +25,13 @@ try:
     from google_crc32c import cext as impl
     implementation = "c"
 except ImportError as exc:
-    from google_crc32c import python as impl
-    warnings.warn(_SLOW_CRC32C_WARNING, RuntimeWarning)
-    implementation = "python"
+    try:
+        from google_crc32c import cffi as impl
+        implementation = "cffi"
+    except ImportError as exc:
+        from google_crc32c import python as impl
+        warnings.warn(_SLOW_CRC32C_WARNING, RuntimeWarning)
+        implementation = "python"
 
 extend = impl.extend
 value = impl.value

--- a/src/google_crc32c/cffi.py
+++ b/src/google_crc32c/cffi.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+
+# NOTE: ``__config__`` **must** be the first import because it (may)
+#       modify the search path used to locate shared libraries.
+import google_crc32c.__config__
+import google_crc32c._crc32c_cffi
+from google_crc32c._checksum import CommonChecksum
+
+
+def extend(crc, chunk):
+    """Update an existing CRC checksum with new chunk of data.
+
+    Args
+        crc (int): An existing CRC check sum.
+        chunk (Union[bytes, List[int], Tuple[int]]): A new chunk of data.
+            Intended to be a byte string or similar.
+
+    Returns
+        int: New CRC checksum computed by extending existing CRC
+        with ``chunk``.
+    """
+    return google_crc32c._crc32c_cffi.lib.crc32c_extend(crc, chunk, len(chunk))
+
+
+def value(chunk):
+    """Compute a CRC checksum for a chunk of data.
+
+    Args
+        chunk (Union[bytes, List[int], Tuple[int]]): A new chunk of data.
+            Intended to be a byte string or similar.
+
+    Returns
+        int: New CRC checksum computed for ``chunk``.
+    """
+    return google_crc32c._crc32c_cffi.lib.crc32c_value(chunk, len(chunk))
+
+
+class Checksum(CommonChecksum):
+    """Hashlib-alike helper for CRC32C operations.
+
+    Args:
+        initial_value (Optional[bytes]): the initial chunk of data from
+            which the CRC32C checksum is computed.  Defaults to b''.
+    """
+
+    __slots__ = ("_crc",)
+
+    def __init__(self, initial_value=b""):
+        self._crc = value(initial_value)
+
+    def update(self, chunk):
+        """Update the checksum with a new chunk of data.
+
+        Args:
+            chunk (Optional[bytes]): a chunk of data used to extend
+                the CRC32C checksum.
+        """
+        self._crc = extend(self._crc, chunk)

--- a/src/google_crc32c_build.py
+++ b/src/google_crc32c_build.py
@@ -1,0 +1,58 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import cffi
+
+def get_kwargs():
+    install_prefix = os.environ.get("CRC32C_INSTALL_PREFIX")
+    if install_prefix is None:
+        return {}
+    install_prefix = os.path.realpath(install_prefix)
+    library_dirs = [os.path.join(install_prefix, "lib")]
+    if os.name == "nt":
+        library_dirs.append(os.path.join(install_prefix, "bin"))
+    rpath = os.pathsep.join(library_dirs)
+
+    if os.name == "nt":
+        extra_link_args = ["-Wl,-rpath={}".format(rpath)]
+    elif os.name == "posix" or os.name == "darwin": # darwin reports this.
+        extra_link_args = ["-Wl,-rpath,{}".format(rpath)]
+    else:
+        extra_link_args = ["-Wl,-rpath={}".format(rpath)]
+
+    return {
+        "library_dirs": library_dirs,
+        "include_dirs": [os.path.join(install_prefix, "include")],
+        "extra_link_args": extra_link_args,
+    }
+
+
+_HEADER = """\
+uint32_t crc32c_extend(uint32_t crc, const uint8_t* data, size_t count);
+uint32_t crc32c_value(const uint8_t* data, size_t count);
+"""
+FFIBUILDER = cffi.FFI()
+FFIBUILDER.cdef(_HEADER)
+FFIBUILDER.set_source(
+    "google_crc32c._crc32c_cffi",
+    '#include "crc32c/crc32c.h"',
+    libraries=["crc32c"],
+    **get_kwargs()
+)
+
+
+if __name__ == "__main__":
+    FFIBUILDER.compile(verbose=True)


### PR DESCRIPTION
- Restore 'check_cffi_crc32c' script
  Make both it and the 'check_crc32c_extension' scripts conditional
  on import

- Make 'pip wheel' run verbosely on CI (to aid debugging of build
  options).

- Drop explicit pre-build of extension: instead, use
  'CRC32C_INSTALL_PREFIX' envvar (when set) to synthesize include /
  library paths for the extension, so that it builds correctly whether
  invoiked direcctly or during a wheel build.