### PR TITLE
ci: temporarily disable build status checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -28,18 +28,19 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - 'build-linux (3.6)'
-    - 'build-linux (3.7)'
-    - 'build-linux (3.8)'
-    - 'build-linux (3.9)'
-    - 'build-macos (3.6)'
-    - 'build-macos (3.7)'
-    - 'build-macos (3.8)'
-    - 'build-macos (3.9)'
-    - 'build-windows (3.6)'
-    - 'build-windows (3.7)'
-    - 'build-windows (3.8)'
-    - 'build-windows (3.9)'
+    # 2021-09-17: temporarily remove build checks to allow replacing them
+    #- 'build-linux (3.6)'
+    #- 'build-linux (3.7)'
+    #- 'build-linux (3.8)'
+    #- 'build-linux (3.9)'
+    #- 'build-macos (3.6)'
+    #- 'build-macos (3.7)'
+    #- 'build-macos (3.8)'
+    #- 'build-macos (3.9)'
+    #- 'build-windows (3.6)'
+    #- 'build-windows (3.7)'
+    #- 'build-windows (3.8)'
+    #- 'build-windows (3.9)'
     - 'cla/google'
 # List of explicit permissions to add (additive only)
 permissionRules:


### PR DESCRIPTION
PR #103 replaces them, but cannot be merged with the requirements still in place.