### PR TITLE
chore: remove spurious required status checks from repo sync

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -28,9 +28,6 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - 'Build / test wheels (presubmit) / ubuntu-20.04 (pull_request)'
-    - 'Build / test wheels (presubmit) / macos-10.15 (pull_request)'
-    - 'Build / test wheels (presubmit) / windows-2019 ( x64 ) (pull_request)'
     - 'cla/google'
 # List of explicit permissions to add (additive only)
 permissionRules:


### PR DESCRIPTION
The checks we *want* to require occur during Github Action checks, which
are different than status checks.