### PR TITLE
feat: add support for Python 3.10

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ import nox
 
 HERE = os.path.dirname(__file__)
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def build_libcrc32c(session):
     session.env["PY_BIN"] = f"python{session.python}"
     session.env["REPO_ROOT"] = HERE
@@ -39,7 +39,7 @@ def build_libcrc32c(session):
         raise Exception("Unsupported")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def check(session):
     session.install("pytest")
     session.install("--no-index", f"--find-links={HERE}/wheels", "google-crc32c")

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     
 [options]
 zip_safe = True


### PR DESCRIPTION
Note that we have been publishing wheels for Python 3.10 for a while.  This PR just makes the support "official" by adding the Trove classifier.