### PR TITLE
fix: add empty slots to CommonChecksum

### DIFF
--- a/src/google_crc32c/_checksum.py
+++ b/src/google_crc32c/_checksum.py
@@ -24,6 +24,7 @@ class CommonChecksum(object):
         initial_value (Optional[bytes]): the initial chunk of data from
             which the CRC32C checksum is computed.  Defaults to b''.
     """
+    __slots__ = ()
 
     def __init__(self, initial_value=b""):
         self._crc = 0


### PR DESCRIPTION
```shell
$ slotscheck -m google_crc32c -v
ERROR: 'google_crc32c.cext:Checksum' has slots but superclass does not.
```

Because `CommonChecksum` doesn't have slots, the slots on `Checksum` are less effective. The fix was easy: adding empty slots to `CommonChecksum`