### PR TITLE
feat: add support for Python 3.11

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -41,7 +41,7 @@ jobs:
       env:
         CIBW_ARCHS_LINUX: x86_64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-        CIBW_SKIP: "cp310-*"  # manylinux1 has no support for 3.10.x Python
+        CIBW_BUILD: "cp3[6-9]-manylinux*"  # manylinux1 has no support for 3.10+ Python or PyPy
         CIBW_ENVIRONMENT: >
             CRC32C_PURE_PYTHON="0"
             CRC32C_INSTALL_PREFIX="$(pwd)/usr"
@@ -51,7 +51,7 @@ jobs:
         # be able to link with it.
         CIBW_BEFORE_BUILD: >
             python -m pip install --upgrade setuptools pip wheel &&
-            python -m pip install cmake &&
+            python -m pip install --only-binary cmake cmake &&
             cmake -S google_crc32c -B build \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCRC32C_BUILD_TESTS=no \

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ import nox
 
 HERE = os.path.dirname(__file__)
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 def build_libcrc32c(session):
     session.env["PY_BIN"] = f"python{session.python}"
     session.env["REPO_ROOT"] = HERE
@@ -39,7 +39,7 @@ def build_libcrc32c(session):
         raise Exception("Unsupported")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 def check(session):
     session.install("pytest")
     session.install("--no-index", f"--find-links={HERE}/wheels", "google-crc32c")

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    
+    Programming Language :: Python :: 3.11
+
 [options]
 zip_safe = True
 python_requires = >=3.6


### PR DESCRIPTION
Python 3.11 is already built and tested with #141
Once CI is fixed (#142 / #143), it should be possible to push 3.11 wheels to PyPI.

Builds on top of #142 / #143 