### PR TITLE
Release candidate v1.6.0rc0

### DIFF
--- a/.kokoro/docker/docs/requirements.txt
+++ b/.kokoro/docker/docs/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes requirements.in
 #
-argcomplete==3.5.0 \
-    --hash=sha256:4349400469dccfb7950bb60334a680c58d88699bff6159df61251878dc6bf74b \
-    --hash=sha256:d4bcf3ff544f51e16e54228a7ac7f486ed70ebf2ecfe49a63a91171c76bf029b
+argcomplete==3.4.0 \
+    --hash=sha256:69a79e083a716173e5532e0fa3bef45f793f4e61096cf52b5a42c0211c8b8aa5 \
+    --hash=sha256:c2abcdfe1be8ace47ba777d4fce319eb13bf8ad9dace8d085dcad6eded88057f
     # via nox
 colorlog==6.8.2 \
     --hash=sha256:3e3e079a41feb5a1b64f978b5ea4f46040a94f11f0e8bbb8261e3dbbeca64d44 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
-## [1.6.0](https://github.com/googleapis/python-crc32c/compare/v1.5.0...v1.6.0) (2024-08-29)
+## [1.6.0rc0](https://github.com/googleapis/python-crc32c/compare/v1.5.0...v1.6.0rc0) (2024-08-29)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
+## [1.6.0](https://github.com/googleapis/python-crc32c/compare/v1.5.0...v1.6.0) (2024-08-29)
+
+
+### Features
+
+* Add support for python 3.12 ([#177](https://github.com/googleapis/python-crc32c/issues/177)) ([5ff1207](https://github.com/googleapis/python-crc32c/commit/5ff1207e7b60256e7a32932324ccb9ad4ec265d2))
+* Build using Visual Studio 17 2022 instead of Visual Studio 16 2019 ([c1c8c59](https://github.com/googleapis/python-crc32c/commit/c1c8c597d07e573406d76765022a837b007f9074))
+
+
+### Bug Fixes
+
+* Drop support for python 3.7 and 3.8 ([c1c8c59](https://github.com/googleapis/python-crc32c/commit/c1c8c597d07e573406d76765022a837b007f9074))
+* Drop support for Windows 32bit which is not supported in Visual Studio 17 2022 ([c1c8c59](https://github.com/googleapis/python-crc32c/commit/c1c8c597d07e573406d76765022a837b007f9074))
+* Remove manylinux1 which is no longer supported by PyPA ([#186](https://github.com/googleapis/python-crc32c/issues/186)) ([79edb3f](https://github.com/googleapis/python-crc32c/commit/79edb3fd3cda0e4193a6fb6a8346058398df43de))
+
 ## [1.5.0](https://github.com/googleapis/python-crc32c/compare/v1.4.0...v1.5.0) (2022-08-31)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = google-crc32c
-version = 1.5.0
+version = 1.6.0
 description = A python wrapper of the C library 'Google CRC32C'
 url = https://github.com/googleapis/python-crc32c
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = google-crc32c
-version = 1.6.0
+version = 1.6.0rc0
 description = A python wrapper of the C library 'Google CRC32C'
 url = https://github.com/googleapis/python-crc32c
 long_description = file: README.md


### PR DESCRIPTION
## [1.6.0rc0](https://github.com/googleapis/python-crc32c/compare/v1.5.0...v1.6.0rc0) (2024-08-29)


### Features

* Add support for python 3.12 ([#177](https://github.com/googleapis/python-crc32c/issues/177)) ([5ff1207](https://github.com/googleapis/python-crc32c/commit/5ff1207e7b60256e7a32932324ccb9ad4ec265d2))
* Build using Visual Studio 17 2022 instead of Visual Studio 16 2019 ([c1c8c59](https://github.com/googleapis/python-crc32c/commit/c1c8c597d07e573406d76765022a837b007f9074))


### Bug Fixes

* Drop support for python 3.7 and 3.8 ([c1c8c59](https://github.com/googleapis/python-crc32c/commit/c1c8c597d07e573406d76765022a837b007f9074))
* Drop support for Windows 32bit which is not supported in Visual Studio 17 2022 ([c1c8c59](https://github.com/googleapis/python-crc32c/commit/c1c8c597d07e573406d76765022a837b007f9074))
* Remove manylinux1 which is no longer supported by PyPA ([#186](https://github.com/googleapis/python-crc32c/issues/186)) ([79edb3f](https://github.com/googleapis/python-crc32c/commit/79edb3fd3cda0e4193a6fb6a8346058398df43de))
