### PR TITLE
chore: Release candidate v1.7.0rc1

### DIFF
--- a/.kokoro/release-windows-wheel.bat
+++ b/.kokoro/release-windows-wheel.bat
@@ -34,7 +34,7 @@ set PYTHONUNBUFFERED=1
 @echo "## Uploading Wheels ##"
 
 @echo "Move into the package, build the distribution and upload."
-set /p TWINE_PASSWORD=<%KOKORO_KEYSTORE_DIR%/73713_google-cloud-pypi-token-keystore-1
+set /p TWINE_PASSWORD=<%KOKORO_KEYSTORE_DIR%/73713_google-cloud-pypi-token-keystore-3
 call py -3 setup.py sdist || goto :error
 call py -3 -m twine upload --skip-existing --username __token__ --password "%TWINE_PASSWORD%" dist/* wheels/google_crc32c* || goto :error
 

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -28,7 +28,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 73713
-      keyname: "google-cloud-pypi-token-keystore-1"
+      keyname: "google-cloud-pypi-token-keystore-3"
     }
   }
 }

--- a/.kokoro/release/linux/common.cfg
+++ b/.kokoro/release/linux/common.cfg
@@ -38,7 +38,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 73713
-      keyname: "google-cloud-pypi-token-keystore-1"
+      keyname: "google-cloud-pypi-token-keystore-3"
     }
   }
 }

--- a/.kokoro/release/osx/common.cfg
+++ b/.kokoro/release/osx/common.cfg
@@ -38,7 +38,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 73713
-      keyname: "google-cloud-pypi-token-keystore-1"
+      keyname: "google-cloud-pypi-token-keystore-3"
     }
   }
 }

--- a/.kokoro/release/windows/common.cfg
+++ b/.kokoro/release/windows/common.cfg
@@ -38,7 +38,7 @@ before_action {
   fetch_keystore {
     keystore_resource {
       keystore_config_id: 73713
-      keyname: "google-cloud-pypi-token-keystore-1"
+      keyname: "google-cloud-pypi-token-keystore-3"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
+## [1.7.0](https://github.com/googleapis/python-crc32c/compare/v1.6.0...v1.7.0) (2025-03-17)
+
+
+### Features
+
+* Add Python 3.13 trove classifier ([#233](https://github.com/googleapis/python-crc32c/issues/233)) ([b125257](https://github.com/googleapis/python-crc32c/commit/b1252575f21d0dde1e131f5251a989f56fb2c0d5))
+* Add support for python 3.13 ([#239](https://github.com/googleapis/python-crc32c/issues/239)) ([6b918f4](https://github.com/googleapis/python-crc32c/commit/6b918f4b081daf3cbee0cbd778b27c98670fb3a4))
+
 ## [1.6.0](https://github.com/googleapis/python-crc32c/compare/v1.5.0...v1.6.0) (2024-08-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
-## [1.7.0](https://github.com/googleapis/python-crc32c/compare/v1.6.0...v1.7.0) (2025-03-17)
+## [1.7.0rc1](https://github.com/googleapis/python-crc32c/compare/v1.6.0...v1.7.0rc1) (2025-03-17)
 
 
 ### Features

--- a/scripts/manylinux/publish_python_wheel.sh
+++ b/scripts/manylinux/publish_python_wheel.sh
@@ -25,5 +25,5 @@ python3.9 -m releasetool publish-reporter-script > /tmp/publisher-script; source
 export PYTHONUNBUFFERED=1
 
 # Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-1")
+TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-3")
 python3.9 -m twine upload --skip-existing --username __token__ --password "${TWINE_PASSWORD}" ${REPO_ROOT}/wheels/*

--- a/scripts/osx/publish_python_wheel.sh
+++ b/scripts/osx/publish_python_wheel.sh
@@ -27,5 +27,5 @@ TWINE=${PYTHON_BIN}/twine
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
-TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-1")
+TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-3")
 ${PYTHON} -m twine upload --skip-existing --username __token__ --password "${TWINE_PASSWORD}" ${REPO_ROOT}/wheels/*

--- a/scripts/osx/publish_python_wheel.sh
+++ b/scripts/osx/publish_python_wheel.sh
@@ -24,8 +24,7 @@ ${PYTHON} -m releasetool publish-reporter-script > /tmp/publisher-script; source
 
 TWINE=${PYTHON_BIN}/twine
 
-# Disable buffering, so that the logs stream through.
-export PYTHONUNBUFFERED=1
-
+# Disable logging
+set +x
 TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-3")
 ${PYTHON} -m twine upload --skip-existing --username __token__ --password "${TWINE_PASSWORD}" ${REPO_ROOT}/wheels/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = google-crc32c
-version = 1.6.0
+version = 1.7.0
 description = A python wrapper of the C library 'Google CRC32C'
 url = https://github.com/googleapis/python-crc32c
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = google-crc32c
-version = 1.7.0
+version = 1.7.0rc1
 description = A python wrapper of the C library 'Google CRC32C'
 url = https://github.com/googleapis/python-crc32c
 long_description = file: README.md


### PR DESCRIPTION
## [1.7.0rc1](https://github.com/googleapis/python-crc32c/compare/v1.6.0...v1.7.0rc1) (2025-03-17)


### Features

* Add Python 3.13 trove classifier ([#233](https://github.com/googleapis/python-crc32c/issues/233)) ([b125257](https://github.com/googleapis/python-crc32c/commit/b1252575f21d0dde1e131f5251a989f56fb2c0d5))
* Add support for python 3.13 ([#239](https://github.com/googleapis/python-crc32c/issues/239)) ([6b918f4](https://github.com/googleapis/python-crc32c/commit/6b918f4b081daf3cbee0cbd778b27c98670fb3a4))
