### PR TITLE
build: update license identifiers in setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Wheels are published for the following platforms / architectures:
 ### Unsupported Platforms
 
 - `manylinux1` platform, `x86_64` architecture support has ended.
+
 See https://github.com/pypa/manylinux/issues/994.
 
 ## Mac OS

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,11 @@ author = Google LLC
 author_email = googleapis-packages@google.com
 
 license = Apache 2.0
+license_files = LICENSE
 platforms = Posix, MacOS X, Windows
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
Fixing lint warnings as license classifiers are deprecated as per the warning in the log below:

```
(.venv) partheniou@partheniou-vm-3:~/git/python-crc32c$ python setup.py check --restructuredtext --strict
#### using global install of 'crc32c'
##### sources: ['src/google_crc32c/_crc32c.c']
##### module kwargs: {}
/usr/local/google/home/partheniou/git/python-crc32c/.venv/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running check
warning: check: Bullet list ends without a blank line; unexpected unindent. (line 27)

Compiling the C Extension for the crc32c library failed. Falling back to pure Python build.
/usr/local/google/home/partheniou/git/python-crc32c/.venv/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running check
warning: check: Bullet list ends without a blank line; unexpected unindent. (line 27)

error: Please correct your package.
```

The change in `README.md` fixes this warning `warning: check: Bullet list ends without a blank line; unexpected unindent. (line 27)`