### PR TITLE
chore: Release candidate v1.7.1rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
+## [1.7.1](https://github.com/googleapis/python-crc32c/compare/v1.7.0...v1.7.1) (2025-03-24)
+
+
+### Bug Fixes
+
+* Add Python 3.13 windows wheels ([fbb0e26](https://github.com/googleapis/python-crc32c/commit/fbb0e26b576fb82b8677b14505e702313cbcfe4e))
+
 ## [1.7.0](https://github.com/googleapis/python-crc32c/compare/v1.6.0...v1.7.0) (2025-03-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
-## [1.7.1](https://github.com/googleapis/python-crc32c/compare/v1.7.0...v1.7.1) (2025-03-24)
+## [1.7.1rc1](https://github.com/googleapis/python-crc32c/compare/v1.7.0...v1.7.1rc1) (2025-03-24)
 
 
 ### Bug Fixes

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = google-crc32c
-version = 1.7.1
+version = 1.7.1rc1
 description = A python wrapper of the C library 'Google CRC32C'
 url = https://github.com/googleapis/python-crc32c
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = google-crc32c
-version = 1.7.0
+version = 1.7.1
 description = A python wrapper of the C library 'Google CRC32C'
 url = https://github.com/googleapis/python-crc32c
 long_description = file: README.md


### PR DESCRIPTION

## [1.7.1rc1](https://github.com/googleapis/python-crc32c/compare/v1.7.0...v1.7.1rc1) (2025-03-24)


### Bug Fixes

* Add Python 3.13 windows wheels ([fbb0e26](https://github.com/googleapis/python-crc32c/commit/fbb0e26b576fb82b8677b14505e702313cbcfe4e))
