### PR TITLE
chore: librarian release pull request: 20251120T132738Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:e601da6e29c993e14c52867f2c088dfb841beae618d2a4f1e0f7970a888ab020
 libraries:
   - id: google-crc32c
-    version: 1.7.1
+    version: 1.8.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
+## [1.8.0](https://github.com/googleapis/python-crc32c/compare/v1.7.1...v1.8.0) (2025-11-20)
+
+
+### Features
+
+* some feature ([b18b353c354750dd478b16677e7b135aef498d51](https://github.com/googleapis/python-crc32c/commit/b18b353c354750dd478b16677e7b135aef498d51))
+
 ## [1.7.1](https://github.com/googleapis/python-crc32c/compare/v1.7.0...v1.7.1) (2025-03-25)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel"]  # PEP 508 specifications.
-version = "1.7.1"
+version = "1.8.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:e601da6e29c993e14c52867f2c088dfb841beae618d2a4f1e0f7970a888ab020
<details><summary>google-crc32c: 1.8.0</summary>

## [1.8.0](https://github.com/googleapis/python-crc32c/compare/v1.7.1...v1.8.0) (2025-11-20)

### Features

* some feature ([b18b353c](https://github.com/googleapis/python-crc32c/commit/b18b353c))

</details>