### PR TITLE
fix: update toml file with setup.cfg content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,37 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [build-system]
-# Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel"]  # PEP 508 specifications.
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "google-crc32c"
 version = "1.7.1"
+description = "A python wrapper of the C library 'Google CRC32C'"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = "1.7.1"
 description = "A python wrapper of the C library 'Google CRC32C'"
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/google_crc32c/_checksum.py
+++ b/src/google_crc32c/_checksum.py
@@ -38,7 +38,7 @@ class CommonChecksum(object):
             chunk (Optional[bytes]): a chunk of data used to extend
                 the CRC32C checksum.
         """
-        raise NotImplemented()
+        raise NotImplementedError
 
     def digest(self):
         """Big-endian order, per RFC 4960.


### PR DESCRIPTION
This PR puts the `version` under the right header. and adds the missing info in pyproject.toml
