### PR TITLE
chore: librarian release pull request: 20251215T113904Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:e601da6e29c993e14c52867f2c088dfb841beae618d2a4f1e0f7970a888ab020
 libraries:
   - id: google-crc32c
-    version: 1.7.1
+    version: 1.8.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [1]: https://pypi.org/project/google-crc32c/#history
 
+## [1.8.0](https://github.com/googleapis/python-crc32c/compare/v1.7.1...v1.8.0) (2025-12-15)
+
+
+### Features
+
+* support Python 3.14 (#315) ([49d0a36f3334048833d0201788fd864d3342d1b2](https://github.com/googleapis/python-crc32c/commit/49d0a36f3334048833d0201788fd864d3342d1b2))
+
+
+### Bug Fixes
+
+* update toml file with setup.cfg content (#319) ([42e5268c7e6077a71e54b342ada4ed2843dbc01e](https://github.com/googleapis/python-crc32c/commit/42e5268c7e6077a71e54b342ada4ed2843dbc01e))
+
 ## [1.7.1](https://github.com/googleapis/python-crc32c/compare/v1.7.0...v1.7.1) (2025-03-25)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "google-crc32c"
-version = "1.7.1"
+version = "1.8.0"
 description = "A python wrapper of the C library 'Google CRC32C'"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:e601da6e29c993e14c52867f2c088dfb841beae618d2a4f1e0f7970a888ab020
<details><summary>google-crc32c: 1.8.0</summary>

## [1.8.0](https://github.com/googleapis/python-crc32c/compare/v1.7.1...v1.8.0) (2025-12-15)

### Features

* support Python 3.14 (#315) ([49d0a36f](https://github.com/googleapis/python-crc32c/commit/49d0a36f))

### Bug Fixes

* update toml file with setup.cfg content (#319) ([42e5268c](https://github.com/googleapis/python-crc32c/commit/42e5268c))

</details>