### PR TITLE
chore: temporarily configure release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: python
+handleGHRelease: true

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,2 @@
+enabled: true
+multiScmName: python-crc32c


### PR DESCRIPTION
Temporarily restore release-please to release https://github.com/googleapis/python-crc32c/pull/315 

BEGIN_COMMIT_OVERRIDE
feat: add support for Python 3.14
END_COMMIT_OVERRIDE