### PR TITLE
chore: Migrate extras config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,9 @@ version = "1.8.0"
 description = "A python wrapper of the C library 'Google CRC32C'"
 readme = "README.md"
 requires-python = ">=3.9"
+
+[project.optional-dependencies]
+testing = ["pytest"]
+
+[tool.setuptools.package-data]
+google_crc32c = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,3 @@ requires-python = ">=3.9"
 
 [project.optional-dependencies]
 testing = ["pytest"]
-
-[tool.setuptools.package-data]
-google_crc32c = ["py.typed"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,10 +39,3 @@ classifiers =
 [options]
 zip_safe = True
 python_requires = >=3.9
-
-[options.extras_require]
-testing = pytest
-
-[options.package_data]
-google_crc32c =
-    py.typed


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-crc32c/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass **no code changes**
- [x] Code coverage does not decrease (if any source code was changed) **no code changes**
- [x] Appropriate docs were updated (if necessary) **N/A**

(Partially) fixes googleapis/google-cloud-python#15664 🦕

After the first commit in this PR:

```
$ pip install .[testing]
[… no warnings, correctly install pytest …]
$ ls -l _e/lib/python3.14/site-packages/google_crc32c/_crc32c.c
-rw-r--r--. 1 ben ben 1428 Dec 16 10:35 _e/lib/python3.14/site-packages/google_crc32c/_crc32c.c
```

Since migrating

```
[options.package_data]
google_crc32c =
    py.typed
```

to

```toml
[tool.setuptools.package-data]
google_crc32c = ["py.typed"]
```

didn’t have the desired effect of not shipping the `_crc32c.c` source file in the wheel, and I don’t know how to acheive that, I just removed the package data configuration. Aftwerard, `py.typed` is still present in the wheel.

This PR does at least fix the `testing` extra.