### PR TITLE
feat: add riscv64 manylinux wheel builds

### DIFF
--- a/.github/workflows/riscv64-wheels.yml
+++ b/.github/workflows/riscv64-wheels.yml
@@ -1,0 +1,37 @@
+name: "Build and test riscv64 wheels"
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-riscv64:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: riscv64
+
+    - name: Build riscv64 wheels
+      run: |
+        docker pull quay.io/pypa/manylinux_2_28_riscv64
+        docker run           --rm           --volume ${{ github.workspace }}:/var/code/python-crc32c/           quay.io/pypa/manylinux_2_28_riscv64           /var/code/python-crc32c/scripts/manylinux/build_on_centos.sh
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: riscv64-wheels
+        path: wheels/

--- a/.github/workflows/riscv64-wheels.yml
+++ b/.github/workflows/riscv64-wheels.yml
@@ -28,7 +28,11 @@ jobs:
     - name: Build riscv64 wheels
       run: |
         docker pull quay.io/pypa/manylinux_2_28_riscv64
-        docker run           --rm           --volume ${{ github.workspace }}:/var/code/python-crc32c/           quay.io/pypa/manylinux_2_28_riscv64           /var/code/python-crc32c/scripts/manylinux/build_on_centos.sh
+        docker run \
+          --rm \
+          --volume ${{ github.workspace }}:/var/code/python-crc32c/ \
+          quay.io/pypa/manylinux_2_28_riscv64 \
+          /var/code/python-crc32c/scripts/manylinux/build_on_centos.sh
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4

--- a/scripts/manylinux/build.sh
+++ b/scripts/manylinux/build.sh
@@ -53,6 +53,15 @@ docker run \
     quay.io/pypa/manylinux2014_aarch64 \
     /var/code/python-crc32c/scripts/manylinux/build_on_centos.sh
 
+docker pull quay.io/pypa/manylinux_2_28_riscv64
+docker run \
+    --rm \
+    --interactive \
+    --volume ${REPO_ROOT}:/var/code/python-crc32c/ \
+    --env BUILD_PYTHON=${BUILD_PYTHON} \
+    quay.io/pypa/manylinux_2_28_riscv64 \
+    /var/code/python-crc32c/scripts/manylinux/build_on_centos.sh
+
 if [[ "${PUBLISH_WHEELS}" == "true" ]]; then
     . /${MANYLINUX_DIR}/publish_python_wheel.sh
 fi


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-crc32c/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes googleapis/google-cloud-python#16517

---

## Summary

Add riscv64 (RISC-V 64-bit) wheel builds to the existing manylinux build pipeline.

### Changes

1. **`scripts/manylinux/build.sh`**: Added a `manylinux_2_28_riscv64` Docker build step after the existing aarch64 step. Uses the official PyPA `quay.io/pypa/manylinux_2_28_riscv64` image. The existing `build_on_centos.sh` script works unmodified inside this container since manylinux_2_28 (AlmaLinux 8) provides the same `yum`/`dnf` package manager and the google/crc32c C library builds cleanly on riscv64.

2. **`.github/workflows/riscv64-wheels.yml`**: New GitHub Actions workflow that builds and tests riscv64 wheels using QEMU user-mode emulation via `docker/setup-qemu-action`. This provides CI visibility for the riscv64 build on pull requests without requiring native RISC-V runners.

### Why manylinux_2_28 instead of manylinux2014?

The `manylinux2014` images are based on CentOS 7, which never had riscv64 support. The `manylinux_2_28` images (AlmaLinux 8) are the earliest manylinux variant available for riscv64, and are officially maintained by PyPA at https://quay.io/repository/pypa/manylinux_2_28_riscv64.

### Testing

The workflow uses QEMU to cross-build riscv64 wheels on x86_64 GitHub Actions runners. The `build_on_centos.sh` script handles building the C library, compiling wheels for all supported Python versions, running `auditwheel repair`, and verifying installation.